### PR TITLE
Deprecate KDL.text => KDL.string

### DIFF
--- a/src/KDL/Decoder/Arrow.hs
+++ b/src/KDL/Decoder/Arrow.hs
@@ -71,6 +71,7 @@ module KDL.Decoder.Arrow (
   ValueDecodeArrow,
   DecodeValue (..),
   any,
+  string,
   text,
   number,
   bool,
@@ -424,7 +425,7 @@ argsAt name = withDecodeValue $ argsAtWith' name
 --     email "a@example.com" "b@example.com"
 --     """
 --   decoder = KDL.document $ proc () -> do
---     KDL.argsAtWith "email" KDL.text -< ()
+--     KDL.argsAtWith "email" KDL.string -< ()
 -- KDL.decodeWith decoder config == Right ["a@example.com", "b@example.com"]
 -- @
 argsAtWith :: forall a b. (Typeable b) => Text -> ValueDecodeArrow a b -> NodeListDecodeArrow a [b]
@@ -470,7 +471,7 @@ dashChildrenAt name = withDecodeValue $ dashChildrenAtWith' name
 --     }
 --     """
 --   decoder = KDL.document $ proc () -> do
---     KDL.dashChildrenAtWith "attendees" $ KDL.text -< ()
+--     KDL.dashChildrenAtWith "attendees" $ KDL.string -< ()
 -- KDL.decodeWith decoder config == Right [\"Alice", \"Bob"]
 -- @
 dashChildrenAtWith :: forall a b. (Typeable b) => Text -> ValueDecodeArrow a b -> NodeListDecodeArrow a [b]
@@ -665,7 +666,7 @@ arg = withDecodeValue argWith'
 --   decoder = KDL.document $ proc () -> do
 --     KDL.nodeWith "person" $ decodePerson -< ()
 --   decodePerson = proc () -> do
---     name \<- KDL.argWith $ Text.toUpper \<$> KDL.text -< ()
+--     name \<- KDL.argWith $ Text.toUpper \<$> KDL.string -< ()
 --     vals \<- KDL.many $ KDL.argWith $ show \<$> KDL.valueDecoder @Int -< ()
 --     returnA -< (name, vals)
 -- KDL.decodeWith decoder config == Right (\"ALICE", ["1", "2", "3"])
@@ -910,11 +911,11 @@ instance DecodeValue Value where
 instance DecodeValue ValueData where
   valueDecoder = (.data_) <$> any
 instance DecodeValue Text where
-  validValueTypeAnns _ = ["text"]
-  valueDecoder = text
+  validValueTypeAnns _ = ["string"]
+  valueDecoder = string
 instance DecodeValue String where
   validValueTypeAnns _ = ["string"]
-  valueDecoder = Text.unpack <$> text
+  valueDecoder = Text.unpack <$> string
 instance DecodeValue Bool where
   validValueTypeAnns _ = ["bool", "boolean"]
   valueDecoder = bool
@@ -1018,11 +1019,16 @@ valueDataDecoderPrim schema f = DecodeArrow schema $ \_ -> Trans.lift . f =<< St
 any :: DecodeArrow Value a Value
 any = valueDataDecoderPrim (SchemaOr $ map SchemaOne [minBound .. maxBound]) pure
 
--- | Decode a KDL text value.
-text :: DecodeArrow Value a Text
-text = valueDataDecoderPrim (SchemaOne TextSchema) $ \case
+-- | Decode a KDL string value.
+string :: DecodeArrow Value a Text
+string = valueDataDecoderPrim (SchemaOne TextSchema) $ \case
   Value{data_ = String s} -> pure s
-  v -> decodeThrow DecodeError_ValueDecodeFail{expectedType = "text", value = v}
+  v -> decodeThrow DecodeError_ValueDecodeFail{expectedType = "string", value = v}
+
+-- | Deprecated in favor of 'string'.
+text :: DecodeArrow Value a Text
+text = string
+{-# DEPRECATED text "Use KDL.string instead" #-}
 
 -- | Decode a KDL number value.
 number :: DecodeArrow Value a Scientific

--- a/test/KDL/ApplicativeSpec.hs
+++ b/test/KDL/ApplicativeSpec.hs
@@ -85,7 +85,7 @@ spec = do
                         KDL.SchemaOne . KDL.NodeArg $
                           KDL.TypedValueSchema
                             { typeHint = typeRep $ Proxy @Text
-                            , validTypeAnns = ["text"]
+                            , validTypeAnns = ["string"]
                             , dataSchema = KDL.SchemaOne KDL.TextSchema
                             }
                     }

--- a/test/KDL/Decoder/ArrowSpec.hs
+++ b/test/KDL/Decoder/ArrowSpec.hs
@@ -121,7 +121,7 @@ apiSpec = do
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
-            , "  Expected text, got: 1.0"
+            , "  Expected string, got: 1.0"
             ]
 
     -- Most behaviors tested with `nodeWith`
@@ -297,7 +297,7 @@ apiSpec = do
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
-            , "  Expected text, got: 1"
+            , "  Expected string, got: 1"
             ]
 
     -- Most behaviors tested with `argAt`
@@ -319,7 +319,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo (test)a"
               decoder = KDL.document $ proc () -> do
-                KDL.argAtWith' "foo" anns KDL.text -< ()
+                KDL.argAtWith' "foo" anns KDL.string -< ()
           KDL.decodeWith decoder config `shouldBe` Right "a"
 
       it "decodes argument without an annotation" $ do
@@ -331,13 +331,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo a"
               decoder = KDL.document $ proc () -> do
-                KDL.argAtWith' "foo" anns KDL.text -< ()
+                KDL.argAtWith' "foo" anns KDL.string -< ()
           KDL.decodeWith decoder config `shouldBe` Right "a"
 
       it "fails when argument has unexpected annotation" $ do
         let config = "foo (test)a"
             decoder = KDL.document $ proc () -> do
-              KDL.argAtWith' "foo" ["VAL"] KDL.text -< ()
+              KDL.argAtWith' "foo" ["VAL"] KDL.string -< ()
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
@@ -392,7 +392,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo (test)a (test)b"
               decoder = KDL.document $ proc () -> do
-                KDL.argsAtWith' "foo" anns KDL.text -< ()
+                KDL.argsAtWith' "foo" anns KDL.string -< ()
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "decodes arguments without an annotation" $ do
@@ -404,13 +404,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo a b"
               decoder = KDL.document $ proc () -> do
-                KDL.argsAtWith' "foo" anns KDL.text -< ()
+                KDL.argsAtWith' "foo" anns KDL.string -< ()
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "fails when argument has unexpected annotation" $ do
         let config = "foo (VAL)a (test)b"
             decoder = KDL.document $ proc () -> do
-              KDL.argsAtWith' "foo" ["VAL"] KDL.text -< ()
+              KDL.argsAtWith' "foo" ["VAL"] KDL.string -< ()
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #1"
@@ -485,7 +485,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo { - (test)a; - (test)b; }"
               decoder = KDL.document $ proc () -> do
-                KDL.dashChildrenAtWith' "foo" anns KDL.text -< ()
+                KDL.dashChildrenAtWith' "foo" anns KDL.string -< ()
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "decodes dash children without an annotation" $ do
@@ -497,13 +497,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo { - a; - b; }"
               decoder = KDL.document $ proc () -> do
-                KDL.dashChildrenAtWith' "foo" anns KDL.text -< ()
+                KDL.dashChildrenAtWith' "foo" anns KDL.string -< ()
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "fails when child has unexpected annotation" $ do
         let config = "foo { - (test)a; }"
             decoder = KDL.document $ proc () -> do
-              KDL.dashChildrenAtWith' "foo" ["VAL"] KDL.text -< ()
+              KDL.dashChildrenAtWith' "foo" ["VAL"] KDL.string -< ()
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > - #0 > arg #0"
@@ -631,7 +631,7 @@ apiSpec = do
       it "decodes an argument" $ do
         let config = "foo bar"
             decoder = proc () -> do
-              KDL.argWith KDL.text -< ()
+              KDL.argWith KDL.string -< ()
         decodeNode "foo" decoder config `shouldBe` Right "bar"
 
     -- Most behaviors tested with `argWith`
@@ -645,7 +645,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo (test)a"
               decoder = proc () -> do
-                KDL.argWith' anns KDL.text -< ()
+                KDL.argWith' anns KDL.string -< ()
           decodeNode "foo" decoder config `shouldBe` Right "a"
 
       it "decodes argument without an annotation" $ do
@@ -657,13 +657,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo a"
               decoder = proc () -> do
-                KDL.argWith' anns KDL.text -< ()
+                KDL.argWith' anns KDL.string -< ()
           decodeNode "foo" decoder config `shouldBe` Right "a"
 
       it "fails when argument has unexpected annotation" $ do
         let config = "foo (test)a"
             decoder = proc () -> do
-              KDL.argWith' ["VAL"] KDL.text -< ()
+              KDL.argWith' ["VAL"] KDL.string -< ()
         decodeNode "foo" decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
@@ -896,21 +896,21 @@ apiSpec = do
         KDL.decodeWith decoder config
           `shouldBe` Right [val $ Number 1, val $ String "asdf", val $ Bool True]
 
-    describe "text" $ do
-      it "decodes text value" $ do
+    describe "string" $ do
+      it "decodes string value" $ do
         let config = "foo asdf"
             decoder = KDL.document $ proc () -> do
-              KDL.argAtWith "foo" KDL.text -< ()
+              KDL.argAtWith "foo" KDL.string -< ()
         KDL.decodeWith decoder config `shouldBe` Right "asdf"
 
-      it "fails when value is not text" $ do
+      it "fails when value is not string" $ do
         let config = "foo 1"
             decoder = KDL.document $ proc () -> do
-              KDL.argAtWith "foo" KDL.text -< ()
+              KDL.argAtWith "foo" KDL.string -< ()
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
-            , "  Expected text, got: 1"
+            , "  Expected string, got: 1"
             ]
 
     describe "number" $ do
@@ -970,7 +970,7 @@ apiSpec = do
         let config = "foo 123 hello"
             decoder = KDL.document $ proc () -> do
               KDL.nodeWith "foo" . KDL.many . KDL.argWith $
-                KDL.oneOf [Left <$> KDL.number, Right <$> KDL.text]
+                KDL.oneOf [Left <$> KDL.number, Right <$> KDL.string]
                 -<
                   ()
         KDL.decodeWith decoder config `shouldBe` Right [Left 123, Right "hello"]
@@ -1059,7 +1059,7 @@ schemaSpec = do
                         KDL.SchemaOne . KDL.NodeArg $
                           KDL.TypedValueSchema
                             { typeHint = typeRep $ Proxy @Text
-                            , validTypeAnns = ["text"]
+                            , validTypeAnns = ["string"]
                             , dataSchema = KDL.SchemaOne KDL.TextSchema
                             }
                     }

--- a/test/KDL/Decoder/MonadSpec.hs
+++ b/test/KDL/Decoder/MonadSpec.hs
@@ -115,7 +115,7 @@ apiSpec = do
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
-            , "  Expected text, got: 1.0"
+            , "  Expected string, got: 1.0"
             ]
 
     -- Most behaviors tested with `nodeWith`
@@ -291,7 +291,7 @@ apiSpec = do
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
-            , "  Expected text, got: 1"
+            , "  Expected string, got: 1"
             ]
 
     -- Most behaviors tested with `argAt`
@@ -313,7 +313,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo (test)a"
               decoder = KDL.document $ do
-                KDL.argAtWith' "foo" anns KDL.text
+                KDL.argAtWith' "foo" anns KDL.string
           KDL.decodeWith decoder config `shouldBe` Right "a"
 
       it "decodes argument without an annotation" $ do
@@ -325,13 +325,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo a"
               decoder = KDL.document $ do
-                KDL.argAtWith' "foo" anns KDL.text
+                KDL.argAtWith' "foo" anns KDL.string
           KDL.decodeWith decoder config `shouldBe` Right "a"
 
       it "fails when argument has unexpected annotation" $ do
         let config = "foo (test)a"
             decoder = KDL.document $ do
-              KDL.argAtWith' "foo" ["VAL"] KDL.text
+              KDL.argAtWith' "foo" ["VAL"] KDL.string
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
@@ -386,7 +386,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo (test)a (test)b"
               decoder = KDL.document $ do
-                KDL.argsAtWith' "foo" anns KDL.text
+                KDL.argsAtWith' "foo" anns KDL.string
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "decodes arguments without an annotation" $ do
@@ -398,13 +398,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo a b"
               decoder = KDL.document $ do
-                KDL.argsAtWith' "foo" anns KDL.text
+                KDL.argsAtWith' "foo" anns KDL.string
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "fails when argument has unexpected annotation" $ do
         let config = "foo (VAL)a (test)b"
             decoder = KDL.document $ do
-              KDL.argsAtWith' "foo" ["VAL"] KDL.text
+              KDL.argsAtWith' "foo" ["VAL"] KDL.string
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #1"
@@ -479,7 +479,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo { - (test)a; - (test)b; }"
               decoder = KDL.document $ do
-                KDL.dashChildrenAtWith' "foo" anns KDL.text
+                KDL.dashChildrenAtWith' "foo" anns KDL.string
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "decodes dash children without an annotation" $ do
@@ -491,13 +491,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo { - a; - b; }"
               decoder = KDL.document $ do
-                KDL.dashChildrenAtWith' "foo" anns KDL.text
+                KDL.dashChildrenAtWith' "foo" anns KDL.string
           KDL.decodeWith decoder config `shouldBe` Right ["a", "b"]
 
       it "fails when child has unexpected annotation" $ do
         let config = "foo { - (test)a; }"
             decoder = KDL.document $ do
-              KDL.dashChildrenAtWith' "foo" ["VAL"] KDL.text
+              KDL.dashChildrenAtWith' "foo" ["VAL"] KDL.string
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > - #0 > arg #0"
@@ -625,7 +625,7 @@ apiSpec = do
       it "decodes an argument" $ do
         let config = "foo bar"
             decoder = do
-              KDL.argWith KDL.text
+              KDL.argWith KDL.string
         decodeNode "foo" decoder config `shouldBe` Right "bar"
 
     -- Most behaviors tested with `argWith`
@@ -639,7 +639,7 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo (test)a"
               decoder = do
-                KDL.argWith' anns KDL.text
+                KDL.argWith' anns KDL.string
           decodeNode "foo" decoder config `shouldBe` Right "a"
 
       it "decodes argument without an annotation" $ do
@@ -651,13 +651,13 @@ apiSpec = do
         forM_ testCases $ \anns -> do
           let config = "foo a"
               decoder = do
-                KDL.argWith' anns KDL.text
+                KDL.argWith' anns KDL.string
           decodeNode "foo" decoder config `shouldBe` Right "a"
 
       it "fails when argument has unexpected annotation" $ do
         let config = "foo (test)a"
             decoder = do
-              KDL.argWith' ["VAL"] KDL.text
+              KDL.argWith' ["VAL"] KDL.string
         decodeNode "foo" decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
@@ -890,21 +890,21 @@ apiSpec = do
         KDL.decodeWith decoder config
           `shouldBe` Right [val $ Number 1, val $ String "asdf", val $ Bool True]
 
-    describe "text" $ do
-      it "decodes text value" $ do
+    describe "string" $ do
+      it "decodes string value" $ do
         let config = "foo asdf"
             decoder = KDL.document $ do
-              KDL.argAtWith "foo" KDL.text
+              KDL.argAtWith "foo" KDL.string
         KDL.decodeWith decoder config `shouldBe` Right "asdf"
 
-      it "fails when value is not text" $ do
+      it "fails when value is not string" $ do
         let config = "foo 1"
             decoder = KDL.document $ do
-              KDL.argAtWith "foo" KDL.text
+              KDL.argAtWith "foo" KDL.string
         KDL.decodeWith decoder config
           `shouldSatisfy` decodeErrorMsg
             [ "At: foo #0 > arg #0"
-            , "  Expected text, got: 1"
+            , "  Expected string, got: 1"
             ]
 
     describe "number" $ do
@@ -964,7 +964,7 @@ apiSpec = do
         let config = "foo 123 hello"
             decoder = KDL.document $ do
               KDL.nodeWith "foo" . KDL.many . KDL.argWith $
-                KDL.oneOf [Left <$> KDL.number, Right <$> KDL.text]
+                KDL.oneOf [Left <$> KDL.number, Right <$> KDL.string]
         KDL.decodeWith decoder config `shouldBe` Right [Left 123, Right "hello"]
 
       it "fails if none can be decoded" $ do

--- a/test/KDL/__snapshots__/DecoderSpec.snap.md
+++ b/test/KDL/__snapshots__/DecoderSpec.snap.md
@@ -24,7 +24,7 @@ At: foo #0 > arg #0
 ```
 Failed to decode test_config.kdl:
 At: foo #1 > bar #0 > baz #3 > prop a
-  Expected text, got: 1
+  Expected string, got: 1
 ```
 
 ## decodeWith / fails with helpful error if parsing fails
@@ -49,5 +49,5 @@ At: foo #0 > arg #0
 
 ```
 At: foo #1 > bar #0 > baz #3 > prop a
-  Expected text, got: 1
+  Expected string, got: 1
 ```


### PR DESCRIPTION
After renaming the constructor to `String` in #18, all references should also be renamed.