### PR TITLE
Rename BaseDecodeError => DecodeErrorKind

### DIFF
--- a/src/KDL/Decoder/Arrow.hs
+++ b/src/KDL/Decoder/Arrow.hs
@@ -12,10 +12,19 @@ module KDL.Decoder.Arrow (
 
   -- * Decoder
   Decoder,
-  module KDL.Decoder.Internal.DecodeM,
+  liftDecodeM,
   fail,
   withDecoder,
   debug,
+
+  -- ** DecodeM
+  DecodeM,
+  runDecodeM,
+  decodeThrow,
+  failM,
+
+  -- ** Decode errors
+  module KDL.Decoder.Internal.Error,
 
   -- * Document
   DocumentDecoder (..),
@@ -112,6 +121,7 @@ import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Int (Int16, Int32, Int8)
 import KDL.Decoder.Internal.DecodeM
 import KDL.Decoder.Internal.Decoder
+import KDL.Decoder.Internal.Error
 import KDL.Decoder.Schema (
   Schema (..),
   SchemaItem (..),

--- a/src/KDL/Decoder/Internal/DecodeM.hs
+++ b/src/KDL/Decoder/Internal/DecodeM.hs
@@ -70,7 +70,7 @@ runDecodeM (DecodeM f) = f Left Left Right
 --
 -- This error is non-fatal and can be handled by '<|>'. See 'makeFatal'
 -- for more information.
-decodeThrow :: BaseDecodeError -> DecodeM a
+decodeThrow :: DecodeErrorKind -> DecodeM a
 decodeThrow e = DecodeM $ \_ onFail _ -> onFail $ DecodeError Nothing [([], e)]
 
 -- | Throw a 'DecodeError_Custom' error.

--- a/src/KDL/Decoder/Internal/Error.hs
+++ b/src/KDL/Decoder/Internal/Error.hs
@@ -7,6 +7,7 @@
 
 module KDL.Decoder.Internal.Error (
   DecodeError (..),
+  BaseDecodeError,
   DecodeErrorKind (..),
   Context,
   ContextItem (..),
@@ -28,7 +29,7 @@ import KDL.Types (
 
 data DecodeError = DecodeError
   { filepath :: Maybe FilePath
-  , errors :: [(Context, DecodeErrorKind)]
+  , errors :: [BaseDecodeError]
   }
   deriving (Show, Eq)
 instance Semigroup DecodeError where
@@ -36,6 +37,7 @@ instance Semigroup DecodeError where
 instance Monoid DecodeError where
   mempty = DecodeError Nothing []
 
+type BaseDecodeError = (Context, DecodeErrorKind)
 type Context = [ContextItem]
 
 data ContextItem

--- a/src/KDL/Decoder/Internal/Error.hs
+++ b/src/KDL/Decoder/Internal/Error.hs
@@ -7,7 +7,7 @@
 
 module KDL.Decoder.Internal.Error (
   DecodeError (..),
-  BaseDecodeError (..),
+  DecodeErrorKind (..),
   Context,
   ContextItem (..),
   renderDecodeError,
@@ -28,7 +28,7 @@ import KDL.Types (
 
 data DecodeError = DecodeError
   { filepath :: Maybe FilePath
-  , errors :: [(Context, BaseDecodeError)]
+  , errors :: [(Context, DecodeErrorKind)]
   }
   deriving (Show, Eq)
 instance Semigroup DecodeError where
@@ -51,7 +51,7 @@ data ContextItem
       }
   deriving (Show, Eq, Ord)
 
-data BaseDecodeError
+data DecodeErrorKind
   = DecodeError_Custom Text
   | DecodeError_ParseError Text
   | DecodeError_ExpectedNode {name :: Text, index :: Int}


### PR DESCRIPTION
Rename `BaseDecodeError` => `DecodeErrorKind` and make `BaseDecodeError` an alias of `(Context, DecodeErrorKind)`

Also prune the re-exports of `KDL.Decoder.Internal.DecodeM` in `KDL.Decoder.Arrow`; it was not intentional to re-export all the internal helper functions.